### PR TITLE
Add list_models function for chat completion in Python client [sc-8367]

### DIFF
--- a/mdai/client.py
+++ b/mdai/client.py
@@ -786,6 +786,16 @@ class ChatCompletion:
         else:
             self.session = requests.Session()
         self.headers = headers
+        self.models = {"gpt-3.5-turbo": ['gpt-3.5-turbo-0613', 'gpt-3.5-turbo-16k-0613', 'gpt-3.5-turbo-0301'],
+                       "gpt-4": ['gpt-4-1106-preview', 'gpt-4-vision-preview', 'gpt-4-0613', 'gpt-4-0314'],
+                       "llama2": ['meta-llama/Llama-2-70b-chat-hf']}
+
+    def list_models(self, model_name=None):
+        if model_name in self.models.keys():
+            print(f"{model_name} available model list: {self.models[model_name]}")
+        else:
+            for model in self.models.keys():
+                print(f"{model} available model list: {self.models[model]}")
 
     def create(
         self,


### PR DESCRIPTION
Added a function to list all available LLM models


Example:

```
>>> mdai_client = mdai.Client(domain='staging.md.ai', access_token=personal_token)
Successfully authenticated to staging.md.ai.
>>> mdai_client.chat_completion.list_models('gpt-3.5-turbo')
gpt-3.5-turbo available model list: ['gpt-3.5-turbo-0613', 'gpt-3.5-turbo-16k-0613', 'gpt-3.5-turbo-0301']
>>> mdai_client.chat_completion.list_models()
gpt-3.5-turbo available model list: ['gpt-3.5-turbo-0613', 'gpt-3.5-turbo-16k-0613', 'gpt-3.5-turbo-0301']
gpt-4 available model list: ['gpt-4-1106-preview', 'gpt-4-vision-preview', 'gpt-4-0613', 'gpt-4-0314']
llama2 available model list: ['meta-llama/Llama-2-70b-chat-hf']
```