### PR TITLE
Add gpt-3.5 and mixtral to model list and correct llama2 model name [sc-8621]

### DIFF
--- a/mdai/client.py
+++ b/mdai/client.py
@@ -786,9 +786,10 @@ class ChatCompletion:
         else:
             self.session = requests.Session()
         self.headers = headers
-        self.models = {"gpt-3.5-turbo": ['gpt-3.5-turbo-0613', 'gpt-3.5-turbo-16k-0613', 'gpt-3.5-turbo-0301'],
+        self.models = {"gpt-3.5-turbo": ['gpt-3.5-turbo-1106', 'gpt-3.5-turbo-0613', 'gpt-3.5-turbo-16k-0613', 'gpt-3.5-turbo-0301'],
                        "gpt-4": ['gpt-4-1106-preview', 'gpt-4-vision-preview', 'gpt-4-0613', 'gpt-4-0314'],
-                       "llama2": ['meta-llama/Llama-2-70b-chat-hf']}
+                       "llama2": ['togethercomputer/llama-2-70b-chat'],
+                       "mixtral": ['mistralai/Mixtral-8x7B-Instruct-v0.1']}
 
     def list_models(self, model_name=None):
         if model_name in self.models.keys():


### PR DESCRIPTION
This PR adds gpt-3.5-turbo-1106 and mixtral models and change the migrated llama2 model name

Example:
`>>> mdai_client.chat_completion.list_models()`
`gpt-3.5-turbo available model list: ['gpt-3.5-turbo-1106', 'gpt-3.5-turbo-0613', 'gpt-3.5-turbo-16k-0613', 'gpt-3.5-turbo-0301']`
`gpt-4 available model list: ['gpt-4-1106-preview', 'gpt-4-vision-preview', 'gpt-4-0613', 'gpt-4-0314']`
`llama2 available model list: ['togethercomputer/llama-2-70b-chat']`
`mixtral available model list: ['mistralai/Mixtral-8x7B-Instruct-v0.1']`